### PR TITLE
SOF/reinstate showstyle variant parsing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,5 @@ RUN apk add --no-cache tzdata git
 COPY . /opt/sofie-inews-gateway
 WORKDIR /opt/sofie-inews-gateway
 RUN yarn install --production
+EXPOSE 3007
 CMD ["yarn", "start"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tv2media/inews-gateway",
-  "version": "46.3.1-staging",
+  "version": "46.3.2-staging",
   "description": "",
   "main": "dist/index.js",
   "contributors": [

--- a/src/helpers/ResolveRundownIntoPlaylist.ts
+++ b/src/helpers/ResolveRundownIntoPlaylist.ts
@@ -28,6 +28,13 @@ export function ResolveRundownIntoPlaylist(
 	let klarOnAirStoryFound = false
 
 	for (const segment of segments) {
+		if (shouldLookForShowstyleVariant(segment, resolvedRundown)) {
+			const showstyleVariantsForSegment = getOrderedShowstyleVariants(segment)
+			if (showstyleVariantsForSegment.length > 0) {
+				setShowstyleVariant(resolvedRundown, showstyleVariantsForSegment[0])
+			}
+		}
+
 		resolvedRundown.segments.push(segment.externalId)
 
 		const isFloated = segment.iNewsStory.meta.float ?? false
@@ -49,6 +56,59 @@ export function ResolveRundownIntoPlaylist(
 	}
 
 	return { resolvedRundown, untimedSegments }
+}
+
+function shouldLookForShowstyleVariant(segment: UnrankedSegment, rundown: ResolvedPlaylistRundown): boolean {
+	const isFloated: boolean = !!segment.iNewsStory.meta.float ?? false
+	const hasShowstyleVariant: boolean = rundown.payload?.showstyleVariant !== undefined
+	return !isFloated && !hasShowstyleVariant
+}
+
+function getOrderedShowstyleVariants(segment: UnrankedSegment): string[] {
+	const cueOrder: number[] = getCueOrder(segment)
+	const orderedShowstyleVariants: string[] = []
+	cueOrder.forEach((cueIndex: number) => {
+		const parsedProfile: string | null = parseShowstyleVariant(segment.iNewsStory.cues[cueIndex] ?? [])
+		if (parsedProfile) {
+			orderedShowstyleVariants.push(parsedProfile)
+		}
+	})
+	return orderedShowstyleVariants
+}
+
+function parseShowstyleVariant(cue: string[]): string | null {
+	const numberOfCueLines: number = cue.length
+
+	// Kommando cue (ignoring timing)
+	const showstyleVariantPattern: RegExp = /^\s*SOFIE\s*=\s*SHOWSTYLEVARIANT/i
+	if (numberOfCueLines >= 2 && showstyleVariantPattern.test(cue![0])) {
+		return cue![1].trim()
+	}
+	return null
+}
+
+/**
+ *
+ * @param segment The segment for which the cue order should be retrieved
+ * @returns A list of indicies representing the cue order.
+ */
+function getCueOrder(segment: UnrankedSegment): number[] {
+	const body = segment.iNewsStory.body ?? ''
+	const refPattern = /<a\s+idref="(?<id>\d+)"\s*\/?>/gi
+	const order: number[] = []
+	let match: RegExpExecArray | null
+	while ((match = refPattern.exec(body))) {
+		let id = parseInt(match.groups!.id, 10)
+		order.push(id)
+	}
+	return order
+}
+
+function setShowstyleVariant(rundown: ResolvedPlaylistRundown, showstyleVariant: string) {
+	rundown.payload = {
+		...(rundown.payload ?? null),
+		showstyleVariant,
+	}
 }
 
 function isKlarOnAir(segment: UnrankedSegment): boolean {


### PR DESCRIPTION
Reverted part of 2b931c27444e1615dab0b448eb8da7adc9d4a3fd, to ensure that the showstyle variant for a rundown is extracted and used. The result of the change is that we (again) support a rundown having a single showstyle variant cue. If multiple are present, then the first from the top of the rundown is used.

Additionally the PR:
- Exposes port 3007 (the HTTP REST endpoint) via the Dockerfile.
- Bumps the version from `46.3.1-staging` to `46.3.2-staging`, to prepare for making a new build.