### PR TITLE
SOF-1770: Register Publish image workflow to repository

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,37 @@
+name: 'Publish image'
+
+run-name: 'Publish image of {{ github.ref_name }} as {{ inputs.versionTag }}'
+
+on:
+  workflow_dispatch:
+    inputs:
+      versionTag:
+        description: 'Version tag (e.g. 1.2.3-staging)'
+        required: true
+        type: 'string'
+
+env:
+  node-version: '16'
+  node-package-manager: 'yarn'
+
+jobs:
+  publish-image-to-docker-hub:
+    name: 'Publish image to Docker Hub'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 'Retrieve repository files'
+        uses: 'actions/checkout@v4'
+
+      - name: 'Log in to Docker Hub'
+        uses: 'docker/login-action@v3'
+        with:
+          username: '${{ secrets.DOCKERHUB_USERNAME }}'
+          password: '${{ secrets.DOCKERHUB_PASSWORD }}'
+
+      - name: 'Build and publish Docker image'
+        uses: 'docker/build-push-action@v5'
+        with:
+          context: '.'
+          push: true
+          tags: |
+            tv2media/inews-ftp-gateway:${{ inputs.versionTag }}


### PR DESCRIPTION
The Publish image workflow is targeted towards `master`, since GitHub Action workflows that are triggered via the `workflow_dispatch` event needs to be on the default branch for to be shown in the GitHub GUI.

The commit that adds the workflow is cherry-picked from #94, to avoid merge conflicts, when those changes reach `master`.